### PR TITLE
Fix missing imports and NameError in bell_chsh.py

### DIFF
--- a/xtheta-lab/README.md
+++ b/xtheta-lab/README.md
@@ -57,6 +57,8 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+> **Note on Python versions**: Development environment used Python 3.14.5, but the project target is Python 3.10+. For reproducible scientific runs, Python 3.11 or 3.12 is recommended.
+
 ## Running the Research Stack
 
 ### 1. Generate Paper 1 Artifacts

--- a/xtheta-lab/xtheta/data/bell_chsh.py
+++ b/xtheta-lab/xtheta/data/bell_chsh.py
@@ -1,11 +1,19 @@
 """
 Correlation and CHSH calculations for Bell-test data.
 """
-import numpy as np
-import math
-from typing import Tuple, List
+from __future__ import annotations
 
-@dataclass
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from xtheta.data.schema import BellEventSchema
+
+
+@dataclass(init=False)
 class RunningAB:
     count: np.ndarray  # shape (4,)
     sum_ab: np.ndarray 
@@ -48,7 +56,7 @@ class RunningAB:
             se_terms.append(var / n)
         return float(np.sqrt(np.sum(se_terms)))
 
-@dataclass
+@dataclass(init=False)
 class ThetaBinnedAB:
     bins: int
     count: np.ndarray  # shape (bins,4)


### PR DESCRIPTION
This change fixes a `NameError` in `xtheta-lab/xtheta/data/bell_chsh.py` where `dataclass` was not defined, causing test collection to fail. It also addresses other missing imports in the same file. Additionally, the documentation in `xtheta-lab/README.md` was updated with a note regarding Python version compatibility for scientific reproducibility.

Key changes:
- Added `from __future__ import annotations` and required imports to `bell_chsh.py`.
- Configured dataclasses to skip automatic `__init__` generation where custom initialization is present.
- Added scientific note about recommended Python versions (3.11/3.12) to README.

---
*PR created automatically by Jules for task [17111475948762533249](https://jules.google.com/task/17111475948762533249) started by @divyang4481*