### PR TITLE
Fix ImportError and SyntaxWarnings

### DIFF
--- a/xtheta-lab/xtheta/data/loaders.py
+++ b/xtheta-lab/xtheta/data/loaders.py
@@ -112,6 +112,24 @@ def iter_dataframes(path: Path, chunksize: int) -> Iterator[pd.DataFrame]:
         return iter_npz(path, chunksize)
     raise ValueError(f"Unsupported file extension: {ext}")
 
+def get_loader(data_path):
+    """
+    Returns a loader function for the given data path.
+    If data_path is a directory, the loader will iterate through all supported files.
+    """
+    path = Path(data_path)
+
+    def loader(p, chunksize=200_000):
+        p = Path(p)
+        if p.is_dir():
+            files = pick_data_files(p)
+            for file_path in files:
+                yield from iter_dataframes(file_path, chunksize=chunksize)
+        else:
+            yield from iter_dataframes(p, chunksize=chunksize)
+
+    return loader
+
 def load_bell_data(filepath, schema_map=None, **kwargs):
     """
     Load Bell test data from various formats.

--- a/xtheta-lab/xtheta/visualization/plots.py
+++ b/xtheta-lab/xtheta/visualization/plots.py
@@ -67,7 +67,7 @@ def plot_correlation_ellipsoid(phi, ax=None, mode="strength", cap=10.0):
     ax.set_zlabel('Z (Correlation)')
 
     title_suffix = "Strength" if mode == "strength" else "Dual Response"
-    ax.set_title(f'Correlation Ellipsoid ({title_suffix}) [$\phi$ = {phi:.4f}]')
+    ax.set_title(rf'Correlation Ellipsoid ({title_suffix}) [$\phi$ = {phi:.4f}]')
 
     return ax
 
@@ -97,17 +97,17 @@ def plot_anisotropy_curve(phi_range):
 
     plt.figure(figsize=(10, 5))
     plt.subplot(1, 2, 1)
-    plt.plot(phi_range, rs, label='$R_{\Theta}$')
-    plt.xlabel('$\phi$')
-    plt.ylabel('$R_{\Theta}$')
+    plt.plot(phi_range, rs, label=r'$R_{\Theta}$')
+    plt.xlabel(r'$\phi$')
+    plt.ylabel(r'$R_{\Theta}$')
     plt.title('Entanglement Anisotropy Invariant')
     plt.legend()
 
     plt.subplot(1, 2, 2)
-    plt.plot(phi_range, chshs, label='$S_{max}$')
-    plt.axhline(y=2*np.sqrt(2), color='r', linestyle='--', label='$2\sqrt{2}$')
-    plt.xlabel('$\phi$')
-    plt.ylabel('$S_{max}$')
+    plt.plot(phi_range, chshs, label=r'$S_{max}$')
+    plt.axhline(y=2*np.sqrt(2), color='r', linestyle='--', label=r'$2\sqrt{2}$')
+    plt.xlabel(r'$\phi$')
+    plt.ylabel(r'$S_{max}$')
     plt.title('Maximum Bell Violation')
     plt.legend()
 
@@ -134,9 +134,9 @@ def plot_random_chsh_landscape(df, output_path=None):
 
     # Limits
     plt.axhline(y=2.0, color='blue', linestyle='--', label='Bell Limit (2.0)')
-    plt.axhline(y=2*np.sqrt(2), color='green', linestyle=':', label='Tsirelson Limit ($2\sqrt{2}$)')
+    plt.axhline(y=2*np.sqrt(2), color='green', linestyle=':', label=r'Tsirelson Limit ($2\sqrt{2}$)')
 
-    plt.xlabel('Relational Phase $\Phi$')
+    plt.xlabel(r'Relational Phase $\Phi$')
     plt.ylabel('CHSH $|S|$')
     plt.title('Random CHSH Landscape and Horodecki Envelope')
     plt.legend(loc='upper right')


### PR DESCRIPTION
This PR addresses two issues reported in the X-Theta framework:
1. An `ImportError` in `scripts/run_open_data_validation.py` caused by a missing `get_loader` function in `xtheta/data/loaders.py`. I implemented `get_loader` as a factory function that returns a loader capable of iterating through files and directories.
2. Multiple `SyntaxWarning` messages in `xtheta/visualization/plots.py` regarding invalid escape sequences in LaTeX strings used for plot labels and titles. I converted these to raw strings (`r'...'` or `rf'...'`) to properly handle backslashes.

Verification:
- All existing tests passed (`pytest tests/ -v`).
- `scripts/generate_paper1_artifacts.py` runs without warnings.
- `scripts/run_open_data_validation.py` successfully processed a mock generic dataset.

---
*PR created automatically by Jules for task [12585272609932296928](https://jules.google.com/task/12585272609932296928) started by @divyang4481*